### PR TITLE
client.get_venues did not pass in external_id parameter

### DIFF
--- a/livestyled/resource_client.py
+++ b/livestyled/resource_client.py
@@ -1008,7 +1008,7 @@ class LiveStyledResourceClient(LiveStyledAPIClient):
             self,
             external_id: str or None = None,
     ) -> Generator[Venue, None, None]:
-        return self._get_resource_list(VenueSchema)
+        return self._get_resource_list(VenueSchema, external_id)
 
     def get_venue(
             self,


### PR DESCRIPTION
Description: 
 when trying to make a call to search for venues by external_id, I am getting a missing iri value. This is because the LiveStyledResourceClient.get_venues isn't passing in the external_id. 

Fix: 
updated LiveStyledResourceClient.get_venues method to pass in external_id. 