### PR TITLE
BE-919 Ticket external_movement_id as another external id option

### DIFF
--- a/livestyled/models/ticket.py
+++ b/livestyled/models/ticket.py
@@ -9,6 +9,7 @@ class Ticket:
             self,
             id,
             external_ticket_id,
+            external_movement_id,
             seat,
             qr_code_url,
             title,
@@ -53,6 +54,7 @@ class Ticket:
     ):
         self.id = id
         self.external_ticket_id = external_ticket_id
+        self.external_movement_id = external_movement_id
         self.seat = seat
         self.qr_code_url = qr_code_url
         self.session_date = session_date
@@ -152,6 +154,7 @@ class Ticket:
         return cls(
             id=id,
             external_ticket_id=None,
+            external_movement_id=None,
             seat=None,
             qr_code_url=None,
             title=None,
@@ -198,6 +201,7 @@ class Ticket:
             cls,
             user: User or str or int,
             external_ticket_id=None,
+            external_movement_id=None,
             seat=None,
             qr_code_url=None,
             session_date=None,
@@ -238,6 +242,7 @@ class Ticket:
         ticket = Ticket(
             id=None,
             external_ticket_id=external_ticket_id,
+            external_movement_id=external_movement_id,
             seat=seat,
             qr_code_url=qr_code_url,
             session_date=session_date,

--- a/livestyled/resource_client.py
+++ b/livestyled/resource_client.py
@@ -582,7 +582,7 @@ class LiveStyledResourceClient(LiveStyledAPIClient):
     ) -> Generator[Ticket, None, None]:
         filters = {}
         if external_ticket_ids:
-            filters['externalTicketId'] = external_ticket_ids
+            filters['externalTicketId[]'] = external_ticket_ids
         if user:
             if isinstance(user, User):
                 filters['user'] = '{}'.format(user.id)

--- a/livestyled/resource_client.py
+++ b/livestyled/resource_client.py
@@ -577,12 +577,12 @@ class LiveStyledResourceClient(LiveStyledAPIClient):
 
     def get_tickets(
             self,
-            external_ticket_id: str or None = None,
+            external_ticket_ids: dict or None = None,
             user: User or str or int or None = None,
     ) -> Generator[Ticket, None, None]:
         filters = {}
-        if external_ticket_id:
-            filters['externalTicketId'] = external_ticket_id
+        if external_ticket_ids:
+            filters['externalTicketId'] = external_ticket_ids
         if user:
             if isinstance(user, User):
                 filters['user'] = '{}'.format(user.id)

--- a/livestyled/schemas/ticket.py
+++ b/livestyled/schemas/ticket.py
@@ -34,6 +34,7 @@ class TicketSchema(Schema):
 
     id = fields.Int()
     external_ticket_id = fields.String(data_key='externalTicketId')
+    external_movement_id = fields.String(data_key='externalMovementId', required=False, missing=None)
     seat = fields.String(required=False, missing=None)
     qr_code_url = fields.String(data_key='qrCodeUrl', required=False, missing=None)
     session_date = fields.AwareDateTime(data_key='sessionDate', allow_none=False)


### PR DESCRIPTION
On SecuTix ticket reservation we set external_ticket_id to SecuTix`s movementId. Thus we need to be able to get_tickets from V4 API by both external_ticket_id and external_movement_id to prevent ticket duplicates.